### PR TITLE
Corrupt JSON due to missing comma

### DIFF
--- a/viewertree.json
+++ b/viewertree.json
@@ -746,7 +746,7 @@
                 "example": ["h96753bff70b74d672524fa570f2fa25ca3", "h21413a56a4c5c72f4ad24528757f989a"],
                 "subscribable": true,
                 "default": [],
-                "dizmojs_version": ["1.3", "1.4"]
+                "dizmojs_version": ["1.3", "1.4"],
                 "[dizmoID]": {
                     "-note": "A value identifying the current docking stage",
                     "write": true,


### PR DESCRIPTION
If you want to verify:

1. Open [this formatter](https://jsonformatter.curiousconcept.com/)
2. Enter URL of base: https://raw.githubusercontent.com/dizmo/docs-viewertree/master/viewertree.json
3. Enter URL of head: https://raw.githubusercontent.com/jvdassen/docs-viewertree/patch-1/viewertree.json